### PR TITLE
W.I.P. streamline code

### DIFF
--- a/SPEAD_1.0/SPEAD_1D.m
+++ b/SPEAD_1.0/SPEAD_1D.m
@@ -210,8 +210,8 @@ if strcmp(keyPARseasonality,'not')
     PAR2D = exp(-kw*zdepths(:))*iparz0;
 end
 
-dat14={itemp,iparz0,PAR2D,imld,iKZ,14,mypackages}
-dat15={mup0,amup,[0.1,0.5,2.0],temp0,Q10a,18:4:30,15}
+dat14={itemp,iparz0,PAR2D,imld,iKZ,14,mypackages};
+dat15={mup0,amup,[0.1,0.5,2.0],temp0,Q10a,18:4:30,15};
 
 %........................................................................
 %========================================================================
@@ -355,7 +355,7 @@ fxytraitphy = fxtraitphy'*fytraitphy;
 %........................................................................
 %========================================================================
 
-dat2020a={xaxis,fxtraitphy,xless,xplus,xmin,xmax,Knless,Knplus,Knmin,Knmax}
+dat2020a={xaxis,fxtraitphy,xless,xplus,xmin,xmax,Knless,Knplus,Knmin,Knmax};
 
 %========================================================================
 %FOR GAUSSIAN DISTRIBUTION OF INITIAL CONDITIONS OF PHYTOPLANKTON: 

--- a/SPEAD_1.0/SPEAD_1D.m
+++ b/SPEAD_1.0/SPEAD_1D.m
@@ -22,7 +22,8 @@ addpath(genpath('TOOLBOX/'));
 %--------------------------------------------------------------------
 %====================================================================
 %--------------------------------------------------------------------
-[mypackages] = myheadloadpackages; %Structure array to pass on my head pkg as input argument to functions.
+doPlotting=false;
+[mypackages] = myheadloadpackages(doPlotting); %Structure array to pass on my head pkg as input argument to functions.
 %--------------------------------------------------------------------
 %MY PACKAGES FOR PLOTING:
 subplot_funhan  = mypackages.subplot;
@@ -31,15 +32,17 @@ verticales = mypackages.verticales;
 horizontal = mypackages.horizontal;
 %--------------------------------------------------------------------
 %JUST CHECKING IF PLOTING WORKS OKAY:
-A256 = peaks(256);
-A128x256 = A256(1:2:256,:);
-A = A128x256;
-Amin = min(A(:));
-Amax = max(A(:));
-fignum = 1001;
-[hcbar] = SPEAD_1D_subplotesting(A,Amin,Amax,fignum,mypackages);
-pause(0.5)
-close all
+if doPlotting
+    A256 = peaks(256);
+    A128x256 = A256(1:2:256,:);
+    A = A128x256;
+    Amin = min(A(:));
+    Amax = max(A(:));
+    fignum = 1001;
+    [hcbar] = SPEAD_1D_subplotesting(A,Amin,Amax,fignum,mypackages);
+    pause(0.5)
+    close all
+end
 %--------------------------------------------------------------------
 %====================================================================
 %********************************************************************
@@ -220,13 +223,15 @@ end
 %........................................................................
 %========================================================================
 
-% Plot external forcings
-fignum = 14;
-SPEAD_1D_imagescforcings(itemp,iparz0,PAR2D,imld,iKZ,fignum,mypackages)
+if doPlotting
+    % Plot external forcings
+    fignum = 14;
+    SPEAD_1D_imagescforcings(itemp,iparz0,PAR2D,imld,iKZ,fignum,mypackages)
 
-% Plot trade-offs
-fignum = 15;
-SPEAD_1D_tradeoff(mup0,amup,[0.1,0.5,2.0],temp0,Q10a,18:4:30,fignum);
+    % Plot trade-offs
+    fignum = 15;
+    SPEAD_1D_tradeoff(mup0,amup,[0.1,0.5,2.0],temp0,Q10a,18:4:30,fignum);
+end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %INITIAL CONDITIONS FOR THE CONTINOUS TRAIT MODEL:
@@ -366,32 +371,34 @@ fytraitphy = (1.0 / (ysigma * sqrt(2*pi))) * exp( -(yaxis - ymean).^2 / (2*ysigm
 fxytraitphy = fxtraitphy'*fytraitphy;
 %........................................................................
 %========================================================================
-figure(2020)
-%...................................................................................
-subplot(2,2,1)
-plot(xaxis,fxtraitphy,'k-',xaxis,fxtraitphy,'b.')
-hold on
-plot(xless,0,'r*',xplus,0,'r*')
-hold off
-set(gca,'Xlim',[xmin xmax])
-set(gca,'Ylim',[0.00 1.00])
-xlabel('log (size)')
-ylabel('f (x)')
-grid on
-%...................................................................................
-subplot(2,2,3)
-plot(Kn,fxtraitphy,'k-',Kn,fxtraitphy,'b.')
-hold on
-plot(Knless,0,'r*',Knplus,0,'r*')
-hold off
-set(gca,'Xlim',[Knmin Knmax])
-set(gca,'Ylim',[0.00 1.00])
-xlabel('log (half-sat)')
-ylabel('f (x)')
-grid on
-%...................................................................................
-pause(1)
-close all
+if doPlotting
+    figure(2020)
+    %...................................................................................
+    subplot(2,2,1)
+    plot(xaxis,fxtraitphy,'k-',xaxis,fxtraitphy,'b.')
+    hold on
+    plot(xless,0,'r*',xplus,0,'r*')
+    hold off
+    set(gca,'Xlim',[xmin xmax])
+    set(gca,'Ylim',[0.00 1.00])
+    xlabel('log (size)')
+    ylabel('f (x)')
+    grid on
+    %...................................................................................
+    subplot(2,2,3)
+    plot(Kn,fxtraitphy,'k-',Kn,fxtraitphy,'b.')
+    hold on
+    plot(Knless,0,'r*',Knplus,0,'r*')
+    hold off
+    set(gca,'Xlim',[Knmin Knmax])
+    set(gca,'Ylim',[0.00 1.00])
+    xlabel('log (half-sat)')
+    ylabel('f (x)')
+    grid on
+    %...................................................................................
+    pause(1)
+    close all
+end
 
 %========================================================================
 %FOR GAUSSIAN DISTRIBUTION OF INITIAL CONDITIONS OF PHYTOPLANKTON: 
@@ -409,17 +416,19 @@ PONdisc0 = pon0 * ones(ndepths*npon,1);
 BOXdisc0 = box0 * ones(ndepths*nbox,1);
 %........................................................................
 %>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-%........................................................................
-figure(10)
-plot(xaxis,fxtraitphy,'-b')
-hold on
-plot(xaxis,fxtraitphy,'r*')
-hold off
-grid on
-%........................................................................
-pause(0.5) 
-close all 
-pause(1)
+if doPlotting
+    %........................................................................
+    figure(10)
+    plot(xaxis,fxtraitphy,'-b')
+    hold on
+    plot(xaxis,fxtraitphy,'r*')
+    hold off
+    grid on
+    %........................................................................
+    pause(0.5) 
+    close all 
+    pause(1)
+end
 %<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 %........................................................................
 %========================================================================
@@ -638,7 +647,7 @@ SPEAD_1D_analysis % Script to analyze the model outputs
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %===================================================================================
 %CONTINOUS:
-if strcmp(key2T,'yes')
+if strcmp(key2T,'yes')&&doPlotting
     %...................................................................................
     fignum = 1010;
     [hfig1010] = SPEAD_1D_imagescuptakerates(MUPsspcont,MUZsspcont,NTOTsspcont,ndepths,ndays,MUPmin,MUPmax,...
@@ -661,7 +670,7 @@ if strcmp(key2T,'yes')
 end
 %===================================================================================
 %DISCRETE:
-if strcmp(keyDisc,'yes')
+if strcmp(keyDisc,'yes')&&doPlotting
     %...................................................................................
     fignum = 2010;
     [hfig2010] = SPEAD_1D_imagescuptakerates(MUPsspdisc,MUZsspdisc,NTOTsspdisc,ndepths,ndays,MUPmin,MUPmax,...
@@ -684,12 +693,12 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %===================================================================================
 %...................................................................................
-if strcmp(key2T,'yes') && strcmp(keyDisc,'yes') && strcmp(keyModelResol,'1D')
+if strcmp(key2T,'yes') && strcmp(keyDisc,'yes') && strcmp(keyModelResol,'1D') && doPlotting
     fignum = [70];
     SPEAD_1D_distribution(PHYTsspcont,logESDphysspAveCont,logESDphysspStdCont,TOPTphysspAveCont,TOPTphysspStdCont,physspCorCont,PHYsspdisc3D,xaxis,yaxis,itemp,DINsspdisc,fignum);
 end
 %...................................................................................
-if strcmp(key2T,'yes') && strcmp(keyKN,'yes') && strcmp(keyTOPT,'yes') 
+if strcmp(key2T,'yes') && strcmp(keyKN,'yes') && strcmp(keyTOPT,'yes')  && doPlotting
     fignum = [80];
     SPEAD_gaussecomodel1D_surftraitplot(DINsspcont,DINsspcont_K,temp(:,1:360),...
     PHYTsspcont,PHYTsspcont_K,PHYTsspcont_T,XAVE_sspcont,XAVE_sspcont_K,XSTD_sspcont,XSTD_sspcont_K,...
@@ -698,7 +707,7 @@ end
 %...................................................................................
 %===================================================================================
 %...................................................................................
-if strcmp(key2T,'yes') && strcmp(keyDisc,'yes')
+if strcmp(key2T,'yes') && strcmp(keyDisc,'yes') && doPlotting
     fignum = [24];
     SPEAD_1D_contvsdiscplot(PHYTsspdisc,PHYTsspcont,logESDphysspAveDisc,logESDphysspAveCont,...
     TOPTphysspAveDisc,TOPTphysspAveCont,logESDphysspStdDisc,logESDphysspStdCont,...

--- a/SPEAD_1.0/SPEAD_1D.m
+++ b/SPEAD_1.0/SPEAD_1D.m
@@ -13,36 +13,26 @@
 %FILE HEADER -- LOAD PACKAGES:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %********************************************************************
-more off
-close all
-clear all
-format short g
+% more off
+% close all
+% clear all
+% format short g
 %--------------------------------------------------------------------
-addpath(genpath('TOOLBOX/'));
+% addpath(genpath('TOOLBOX/'));
 %--------------------------------------------------------------------
 %====================================================================
 %--------------------------------------------------------------------
-doPlotting=false;
-[mypackages] = myheadloadpackages(doPlotting); %Structure array to pass on my head pkg as input argument to functions.
+
+function [dat14,dat15,dat2020a,dat1010,dat1020,dat1022,dat1030,...
+    dat2010,dat2020,dat2030,dat70,dat80,dat24]=SPEAD_1D()
+
+[mypackages] = myheadloadpackages(false); %Structure array to pass on my head pkg as input argument to functions.
 %--------------------------------------------------------------------
 %MY PACKAGES FOR PLOTING:
 subplot_funhan  = mypackages.subplot;
 colorbar_funhan = mypackages.colorbar;
 verticales = mypackages.verticales;
 horizontal = mypackages.horizontal;
-%--------------------------------------------------------------------
-%JUST CHECKING IF PLOTING WORKS OKAY:
-if doPlotting
-    A256 = peaks(256);
-    A128x256 = A256(1:2:256,:);
-    A = A128x256;
-    Amin = min(A(:));
-    Amax = max(A(:));
-    fignum = 1001;
-    [hcbar] = SPEAD_1D_subplotesting(A,Amin,Amax,fignum,mypackages);
-    pause(0.5)
-    close all
-end
 %--------------------------------------------------------------------
 %====================================================================
 %********************************************************************
@@ -220,18 +210,11 @@ if strcmp(keyPARseasonality,'not')
     PAR2D = exp(-kw*zdepths(:))*iparz0;
 end
 
+dat14={itemp,iparz0,PAR2D,imld,iKZ,14,mypackages}
+dat15={mup0,amup,[0.1,0.5,2.0],temp0,Q10a,18:4:30,15}
+
 %........................................................................
 %========================================================================
-
-if doPlotting
-    % Plot external forcings
-    fignum = 14;
-    SPEAD_1D_imagescforcings(itemp,iparz0,PAR2D,imld,iKZ,fignum,mypackages)
-
-    % Plot trade-offs
-    fignum = 15;
-    SPEAD_1D_tradeoff(mup0,amup,[0.1,0.5,2.0],temp0,Q10a,18:4:30,fignum);
-end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %INITIAL CONDITIONS FOR THE CONTINOUS TRAIT MODEL:
@@ -371,34 +354,8 @@ fytraitphy = (1.0 / (ysigma * sqrt(2*pi))) * exp( -(yaxis - ymean).^2 / (2*ysigm
 fxytraitphy = fxtraitphy'*fytraitphy;
 %........................................................................
 %========================================================================
-if doPlotting
-    figure(2020)
-    %...................................................................................
-    subplot(2,2,1)
-    plot(xaxis,fxtraitphy,'k-',xaxis,fxtraitphy,'b.')
-    hold on
-    plot(xless,0,'r*',xplus,0,'r*')
-    hold off
-    set(gca,'Xlim',[xmin xmax])
-    set(gca,'Ylim',[0.00 1.00])
-    xlabel('log (size)')
-    ylabel('f (x)')
-    grid on
-    %...................................................................................
-    subplot(2,2,3)
-    plot(Kn,fxtraitphy,'k-',Kn,fxtraitphy,'b.')
-    hold on
-    plot(Knless,0,'r*',Knplus,0,'r*')
-    hold off
-    set(gca,'Xlim',[Knmin Knmax])
-    set(gca,'Ylim',[0.00 1.00])
-    xlabel('log (half-sat)')
-    ylabel('f (x)')
-    grid on
-    %...................................................................................
-    pause(1)
-    close all
-end
+
+dat2020a={xaxis,fxtraitphy,xless,xplus,xmin,xmax,Knless,Knplus,Knmin,Knmax}
 
 %========================================================================
 %FOR GAUSSIAN DISTRIBUTION OF INITIAL CONDITIONS OF PHYTOPLANKTON: 
@@ -414,22 +371,6 @@ ZOOdisc0 = zoo0 * ones(ndepths*nzoo,1);
 DINdisc0 = din0 * ones(ndepths*ndin,1);
 PONdisc0 = pon0 * ones(ndepths*npon,1);
 BOXdisc0 = box0 * ones(ndepths*nbox,1);
-%........................................................................
-%>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-if doPlotting
-    %........................................................................
-    figure(10)
-    plot(xaxis,fxtraitphy,'-b')
-    hold on
-    plot(xaxis,fxtraitphy,'r*')
-    hold off
-    grid on
-    %........................................................................
-    pause(0.5) 
-    close all 
-    pause(1)
-end
-%<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 %........................................................................
 %========================================================================
 %COLUMN VECTOR OF INITIAL CONDITIONS:
@@ -647,43 +588,43 @@ SPEAD_1D_analysis % Script to analyze the model outputs
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %===================================================================================
 %CONTINOUS:
-if strcmp(key2T,'yes')&&doPlotting
+if strcmp(key2T,'yes')
     %...................................................................................
     fignum = 1010;
-    [hfig1010] = SPEAD_1D_imagescuptakerates(MUPsspcont,MUZsspcont,NTOTsspcont,ndepths,ndays,MUPmin,MUPmax,...
-        MUZmin,MUZmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    dat1010 = {MUPsspcont,MUZsspcont,NTOTsspcont,ndepths,ndays,MUPmin,MUPmax,...
+        MUZmin,MUZmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages};
     %...................................................................................
     fignum = 1020;
-    [hfig1020] = SPEAD_1D_imagescNPZD(NTOTsspcont,CHLsspcont,PPsspcont,ZOOsspcont,DINsspcont,PONsspcont,ndepths,ndays,PHYmin,PHYmax,...
-        ZOOmin,ZOOmax,DINmin,DINmax,PONmin,PONmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    dat1020 = {NTOTsspcont,CHLsspcont,PPsspcont,ZOOsspcont,DINsspcont,PONsspcont,ndepths,ndays,PHYmin,PHYmax,...
+        ZOOmin,ZOOmax,DINmin,DINmax,PONmin,PONmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages};
     %...................................................................................
     % Compare model and observations
     fignum = 1022;
-    [hfig1022] = SPEAD_gaussecomodel1D_imagescmodvsobs(12*(106/16)*PP_obs,CHL_obs,NO3_obs,PON_obs,12*(106/16)*PPsspcont,...
-        CHLsspcont,DINsspcont,PONsspcont,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    dat1022 = {12*(106/16)*PP_obs,CHL_obs,NO3_obs,PON_obs,12*(106/16)*PPsspcont,...
+        CHLsspcont,DINsspcont,PONsspcont,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages};
     %...................................................................................
     fignum = 1030;
-    [hfig1030] = SPEAD_1D_imagescstatistics(logESDphysspAveCont,logESDphysspStdCont,TOPTphysspAveCont,TOPTphysspStdCont,physspCorCont,PHYTsspcont,...
+    dat1030 = {logESDphysspAveCont,logESDphysspStdCont,TOPTphysspAveCont,TOPTphysspStdCont,physspCorCont,PHYTsspcont,...
         ndepths,ndays,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,logESDaveMax,logESDaveMin,logESDstdMax,logESDstdMin,...
-        TOPTaveMax,TOPTaveMin,TOPTstdMax,TOPTstdMin,CorrelationAbsMax,fignum,mypackages);
+        TOPTaveMax,TOPTaveMin,TOPTstdMax,TOPTstdMin,CorrelationAbsMax,fignum,mypackages};
     %...................................................................................
 end
 %===================================================================================
 %DISCRETE:
-if strcmp(keyDisc,'yes')&&doPlotting
+if strcmp(keyDisc,'yes')
     %...................................................................................
     fignum = 2010;
-    [hfig2010] = SPEAD_1D_imagescuptakerates(MUPsspdisc,MUZsspdisc,NTOTsspdisc,ndepths,ndays,MUPmin,MUPmax,...
-        MUZmin,MUZmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    dat2010 = {MUPsspdisc,MUZsspdisc,NTOTsspdisc,ndepths,ndays,MUPmin,MUPmax,...
+        MUZmin,MUZmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages};
     %...................................................................................
     fignum = 2020;
-    [hfig2020] = SPEAD_1D_imagescNPZD(NTOTsspdisc,CHLsspdisc,PPsspdisc,ZOOsspdisc,DINsspdisc,PONsspdisc,ndepths,ndays,PHYmin,PHYmax,...
-        ZOOmin,ZOOmax,DINmin,DINmax,PONmin,PONmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    dat2020 = {NTOTsspdisc,CHLsspdisc,PPsspdisc,ZOOsspdisc,DINsspdisc,PONsspdisc,ndepths,ndays,PHYmin,PHYmax,...
+        ZOOmin,ZOOmax,DINmin,DINmax,PONmin,PONmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages};
     %...................................................................................
     fignum = 2030;
-    [hfig2030] = SPEAD_1D_imagescstatistics(logESDphysspAveDisc,logESDphysspStdDisc,TOPTphysspAveDisc,TOPTphysspStdDisc,physspCorDisc,PHYTsspdisc,...
+    dat2030 = {logESDphysspAveDisc,logESDphysspStdDisc,TOPTphysspAveDisc,TOPTphysspStdDisc,physspCorDisc,PHYTsspdisc,...
         ndepths,ndays,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,logESDaveMax,logESDaveMin,logESDstdMax,logESDstdMin,...
-        TOPTaveMax,TOPTaveMin,TOPTstdMax,TOPTstdMin,CorrelationAbsMax,fignum,mypackages);
+        TOPTaveMax,TOPTaveMin,TOPTstdMax,TOPTstdMin,CorrelationAbsMax,fignum,mypackages};
     %...................................................................................
 end
 %===================================================================================
@@ -692,27 +633,29 @@ end
 %PLOTS OF TRAIT DISTRIBUTION:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %===================================================================================
-%...................................................................................
-if strcmp(key2T,'yes') && strcmp(keyDisc,'yes') && strcmp(keyModelResol,'1D') && doPlotting
+if strcmp(key2T,'yes') && strcmp(keyDisc,'yes') && strcmp(keyModelResol,'1D')
     fignum = [70];
-    SPEAD_1D_distribution(PHYTsspcont,logESDphysspAveCont,logESDphysspStdCont,TOPTphysspAveCont,TOPTphysspStdCont,physspCorCont,PHYsspdisc3D,xaxis,yaxis,itemp,DINsspdisc,fignum);
+    dat70 = {PHYTsspcont,logESDphysspAveCont,logESDphysspStdCont,TOPTphysspAveCont,TOPTphysspStdCont,physspCorCont,PHYsspdisc3D,xaxis,yaxis,itemp,DINsspdisc,fignum};
 end
 %...................................................................................
-if strcmp(key2T,'yes') && strcmp(keyKN,'yes') && strcmp(keyTOPT,'yes')  && doPlotting
+if strcmp(key2T,'yes') && strcmp(keyKN,'yes') && strcmp(keyTOPT,'yes')
     fignum = [80];
-    SPEAD_gaussecomodel1D_surftraitplot(DINsspcont,DINsspcont_K,temp(:,1:360),...
+    dat80 = {DINsspcont,DINsspcont_K,temp(:,1:360),...
     PHYTsspcont,PHYTsspcont_K,PHYTsspcont_T,XAVE_sspcont,XAVE_sspcont_K,XSTD_sspcont,XSTD_sspcont_K,...
-    YAVE_sspcont,YAVE_sspcont_T,YSTD_sspcont,YSTD_sspcont_T,XYCOR_sspcont,fignum);
+    YAVE_sspcont,YAVE_sspcont_T,YSTD_sspcont,YSTD_sspcont_T,XYCOR_sspcont,fignum};
 end
 %...................................................................................
 %===================================================================================
 %...................................................................................
-if strcmp(key2T,'yes') && strcmp(keyDisc,'yes') && doPlotting
+if strcmp(key2T,'yes') && strcmp(keyDisc,'yes')
     fignum = [24];
-    SPEAD_1D_contvsdiscplot(PHYTsspdisc,PHYTsspcont,logESDphysspAveDisc,logESDphysspAveCont,...
+    dat24 = {PHYTsspdisc,PHYTsspcont,logESDphysspAveDisc,logESDphysspAveCont,...
     TOPTphysspAveDisc,TOPTphysspAveCont,logESDphysspStdDisc,logESDphysspStdCont,...
-    TOPTphysspStdDisc,TOPTphysspStdCont,physspCorDisc,physspCorCont,ndepths,fignum);
+    TOPTphysspStdDisc,TOPTphysspStdCont,physspCorDisc,physspCorCont,ndepths,fignum};
 end
+%...................................................................................
+
+%===================================================================================
 %...................................................................................
 if strcmp(key2T,'yes') && strcmp(keyDisc,'yes')
     disp('Mean error and root mean square error on total phytoplankton, mean size and standard deviation (truth is the discrete model)')
@@ -744,4 +687,7 @@ if strcmp(key2T,'yes')
 end
 %...................................................................................
 %***********************************************************************************
-return
+% return
+
+end %function []=SPEAD_1D_main()
+

--- a/SPEAD_1.0/SPEAD_1D_plots.m
+++ b/SPEAD_1.0/SPEAD_1D_plots.m
@@ -1,0 +1,138 @@
+
+
+%expected inputs: key2T, keyDisc, keyModelResol, keyKN, keyTOPT
+
+function []=SPEAD_1D_plot()
+
+%JUST CHECKING IF PLOTING WORKS OKAY:
+A256 = peaks(256);
+A128x256 = A256(1:2:256,:);
+A = A128x256;
+Amin = min(A(:));
+Amax = max(A(:));
+fignum = 1001;
+[hcbar] = SPEAD_1D_subplotesting(A,Amin,Amax,fignum,mypackages);
+pause(0.5)
+close all
+
+% Plot external forcings
+fignum = 14;
+SPEAD_1D_imagescforcings(itemp,iparz0,PAR2D,imld,iKZ,fignum,mypackages)
+
+% Plot trade-offs
+fignum = 15;
+SPEAD_1D_tradeoff(mup0,amup,[0.1,0.5,2.0],temp0,Q10a,18:4:30,fignum);
+
+%........................................................................
+figure(10)
+plot(xaxis,fxtraitphy,'-b')
+hold on
+plot(xaxis,fxtraitphy,'r*')
+hold off
+grid on
+%........................................................................
+pause(0.5) 
+close all 
+pause(1)
+
+figure(2020)
+%...................................................................................
+subplot(2,2,1)
+plot(xaxis,fxtraitphy,'k-',xaxis,fxtraitphy,'b.')
+hold on
+plot(xless,0,'r*',xplus,0,'r*')
+hold off
+set(gca,'Xlim',[xmin xmax])
+set(gca,'Ylim',[0.00 1.00])
+xlabel('log (size)')
+ylabel('f (x)')
+grid on
+%...................................................................................
+subplot(2,2,3)
+plot(Kn,fxtraitphy,'k-',Kn,fxtraitphy,'b.')
+hold on
+plot(Knless,0,'r*',Knplus,0,'r*')
+hold off
+set(gca,'Xlim',[Knmin Knmax])
+set(gca,'Ylim',[0.00 1.00])
+xlabel('log (half-sat)')
+ylabel('f (x)')
+grid on
+%...................................................................................
+pause(1)
+close all
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%PLOT STATISTICS OF BOTH CONTINUOUS AND DISCRETE MODEL:
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%===================================================================================
+%CONTINOUS:
+if strcmp(key2T,'yes')
+    %...................................................................................
+    fignum = 1010;
+    [hfig1010] = SPEAD_1D_imagescuptakerates(MUPsspcont,MUZsspcont,NTOTsspcont,ndepths,ndays,MUPmin,MUPmax,...
+        MUZmin,MUZmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    %...................................................................................
+    fignum = 1020;
+    [hfig1020] = SPEAD_1D_imagescNPZD(NTOTsspcont,CHLsspcont,PPsspcont,ZOOsspcont,DINsspcont,PONsspcont,ndepths,ndays,PHYmin,PHYmax,...
+        ZOOmin,ZOOmax,DINmin,DINmax,PONmin,PONmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    %...................................................................................
+    % Compare model and observations
+    fignum = 1022;
+    [hfig1022] = SPEAD_gaussecomodel1D_imagescmodvsobs(12*(106/16)*PP_obs,CHL_obs,NO3_obs,PON_obs,12*(106/16)*PPsspcont,...
+        CHLsspcont,DINsspcont,PONsspcont,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    %...................................................................................
+    fignum = 1030;
+    [hfig1030] = SPEAD_1D_imagescstatistics(logESDphysspAveCont,logESDphysspStdCont,TOPTphysspAveCont,TOPTphysspStdCont,physspCorCont,PHYTsspcont,...
+        ndepths,ndays,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,logESDaveMax,logESDaveMin,logESDstdMax,logESDstdMin,...
+        TOPTaveMax,TOPTaveMin,TOPTstdMax,TOPTstdMin,CorrelationAbsMax,fignum,mypackages);
+    %...................................................................................
+end
+%===================================================================================
+%DISCRETE:
+if strcmp(keyDisc,'yes')
+    %...................................................................................
+    fignum = 2010;
+    [hfig2010] = SPEAD_1D_imagescuptakerates(MUPsspdisc,MUZsspdisc,NTOTsspdisc,ndepths,ndays,MUPmin,MUPmax,...
+        MUZmin,MUZmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    %...................................................................................
+    fignum = 2020;
+    [hfig2020] = SPEAD_1D_imagescNPZD(NTOTsspdisc,CHLsspdisc,PPsspdisc,ZOOsspdisc,DINsspdisc,PONsspdisc,ndepths,ndays,PHYmin,PHYmax,...
+        ZOOmin,ZOOmax,DINmin,DINmax,PONmin,PONmax,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,fignum,mypackages);
+    %...................................................................................
+    fignum = 2030;
+    [hfig2030] = SPEAD_1D_imagescstatistics(logESDphysspAveDisc,logESDphysspStdDisc,TOPTphysspAveDisc,TOPTphysspStdDisc,physspCorDisc,PHYTsspdisc,...
+        ndepths,ndays,myXtickMarks,myXtickLabel,myYtickMarks,myYtickLabel,myYaxisLabel,logESDaveMax,logESDaveMin,logESDstdMax,logESDstdMin,...
+        TOPTaveMax,TOPTaveMin,TOPTstdMax,TOPTstdMin,CorrelationAbsMax,fignum,mypackages);
+    %...................................................................................
+end
+%===================================================================================
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%PLOTS OF TRAIT DISTRIBUTION:
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%===================================================================================
+if strcmp(key2T,'yes') && strcmp(keyDisc,'yes') && strcmp(keyModelResol,'1D')
+    fignum = [70];
+    SPEAD_1D_distribution(PHYTsspcont,logESDphysspAveCont,logESDphysspStdCont,TOPTphysspAveCont,TOPTphysspStdCont,physspCorCont,PHYsspdisc3D,xaxis,yaxis,itemp,DINsspdisc,fignum);
+end
+%...................................................................................
+if strcmp(key2T,'yes') && strcmp(keyKN,'yes') && strcmp(keyTOPT,'yes')
+    fignum = [80];
+    SPEAD_gaussecomodel1D_surftraitplot(DINsspcont,DINsspcont_K,temp(:,1:360),...
+    PHYTsspcont,PHYTsspcont_K,PHYTsspcont_T,XAVE_sspcont,XAVE_sspcont_K,XSTD_sspcont,XSTD_sspcont_K,...
+    YAVE_sspcont,YAVE_sspcont_T,YSTD_sspcont,YSTD_sspcont_T,XYCOR_sspcont,fignum);
+end
+%...................................................................................
+%===================================================================================
+%...................................................................................
+if strcmp(key2T,'yes') && strcmp(keyDisc,'yes')
+    fignum = [24];
+    SPEAD_1D_contvsdiscplot(PHYTsspdisc,PHYTsspcont,logESDphysspAveDisc,logESDphysspAveCont,...
+    TOPTphysspAveDisc,TOPTphysspAveCont,logESDphysspStdDisc,logESDphysspStdCont,...
+    TOPTphysspStdDisc,TOPTphysspStdCont,physspCorDisc,physspCorCont,ndepths,fignum);
+end
+%...................................................................................
+
+end
+

--- a/SPEAD_1.0/SPEAD_1D_save.m
+++ b/SPEAD_1.0/SPEAD_1D_save.m
@@ -1,0 +1,28 @@
+function []=SPEAD_1D_save(dat14,dat15,dat2020a,dat1010,...
+    dat1020,dat1022,dat1030,dat2010,dat2020,dat2030,dat70,dat80,dat24)
+%Save output from SPEAD_1D.
+%
+%Usage : 
+%
+% [dat14,dat15,dat2020a,dat1010,dat1020,dat1022,dat1030,...
+%  dat2010,dat2020,dat2030,dat70,dat80,dat24]=SPEAD_1D();
+% 
+% SPEAD_1D_save( dat14,dat15,dat2020a,dat1010,dat1020,dat1022,dat1030,...
+%                       dat2010,dat2020,dat2030,dat70,dat80,dat24)
+
+    fil14=SPEAD_1D_save_fig14(dat14)
+end
+
+function [fil]=SPEAD_1D_save_one(fil,nam,dat)
+    tmp1=struct();
+    for i=1:length(nam)
+        tmp1.(nam{i})=dat(i);
+    end
+    save(fil,'-struct','tmp1');
+end
+
+function [fil]=SPEAD_1D_save_fig14(dat)
+    fil=fullfile(tempdir(),"SPEAD_1D_fig14.mat");
+    nam={'itemp','iparz0','PAR2D','imld','iKZ','fignum','mypackages'};
+    SPEAD_1D_save_one(fil,nam,dat);
+end

--- a/SPEAD_1.0/TOOLBOX/MYFUNCTIONS/myheadloadpackages.m
+++ b/SPEAD_1.0/TOOLBOX/MYFUNCTIONS/myheadloadpackages.m
@@ -1,10 +1,10 @@
-function [mypackages] = myheadloadpackages()
+function [mypackages] = myheadloadpackages(doPlotting)
 
 %****************************************************************************
 % PROGRAM: MYHEADLOADPACKAGES.M
 %
 % ## Use: myheadloadpackages
-% Use: [subplot_funhan,colorbar_funhan,verticales,horizontal] = myheadloadpackages;
+% Use: [subplot_funhan,colorbar_funhan,verticales,horizontal] = myheadloadpackages(doPlotting);
 %
 %****************************************************************************
 
@@ -25,10 +25,10 @@ function [mypackages] = myheadloadpackages()
 %============================================================================
 % LOAD COMMON PACKAGES:
 %----------------------------------------------------------------------------
-more off
-close all
-clear all
-format short g
+%more off
+%close all
+%clear all
+%format short g
 %----------------------------------------------------------------------------
 % $$$ addpath('~/SERVAL/SER24/PROGRAMMING/MATLAB/PROGRAMAS/MYFUNCTIONS/');
 %----------------------------------------------------------------------------
@@ -87,17 +87,21 @@ elseif uiIsOctave == 1 %OCTAVE
     % <https://stackoverflow.com/questions/41040999/speed-up-printing-of-mesh-in-octave>
     %%FunctionName_Colorbar = 'colorbar';
     FunctionName_Colorbar = 'mycolorbarOctave3p4';
-    colorbar_location = get(eval(FunctionName_Colorbar),'Location');
+    if doPlotting
+        colorbar_location = get(eval(FunctionName_Colorbar),'Location');
+    end
     colorbar_location_vertical = 'EastOutside';
     colorbar_location_horizont = 'SouthOutside';
     close all
     FunctionHandle_Colorbar = str2func(FunctionName_Colorbar);
     colorbar_funhan = FunctionHandle_Colorbar;
     available_graphics_toolkits()
-    graphics_toolkit('fltk') %FASTER FOR IMAGESC BUT SLOWER FOR PLOTTING
-    %%graphics_toolkit('gnuplot') %FASTER FOR PLOT BUT SLOWER FOR IMAGESC
+    if doPlotting
+        graphics_toolkit('fltk') %FASTER FOR IMAGESC BUT SLOWER FOR PLOTTING
+        %%graphics_toolkit('gnuplot') %FASTER FOR PLOT BUT SLOWER FOR IMAGESC
+    end
     gnuplot_binary('gnuplot')
-    jit_enable(0)  %JIT accelarator -- disabled (0) or enabled (1)
+    %jit_enable(0)  %JIT accelarator -- disabled (0) or enabled (1)
     %%jit_enable_asking = jit_enable %%JIT accelarator when disabled (0) or enabled (1)
 end
 %============================================================================
@@ -115,17 +119,19 @@ FunctionHandle_subplot = str2func(FunctionName_subplot);
 subplot_funhan = FunctionHandle_subplot;
 %----------------------------------------------------------------------------
 %JUST CHECKING IF PLOTTING (SUBPLOT AND COLORBAR) IS WORKING OKAY:
-figure(1)
-subplot_funhan(2,2,1);
-hcbar = colorbar_funhan(verticales); 
-subplot_funhan(2,2,2);
-hcbar = colorbar_funhan(horizontal);
-%----------------------------------------------------------------------------
-subplot_funhan
-colorbar_funhan
-disp('** Just checking MATLAB / OCTAVE plotting -- please wait 1 sec **')
-pause(0.5)
-close all
+if doPlotting
+    figure(1)
+    subplot_funhan(2,2,1);
+    hcbar = colorbar_funhan(verticales); 
+    subplot_funhan(2,2,2);
+    hcbar = colorbar_funhan(horizontal);
+    %----------------------------------------------------------------------------
+    subplot_funhan
+    colorbar_funhan
+    disp('** Just checking MATLAB / OCTAVE plotting -- please wait 1 sec **')
+    pause(0.5)
+    close all
+end
 %----------------------------------------------------------------------------
 %============================================================================
 %OUTPUTS:


### PR DESCRIPTION
The motivation for changes in this PR was to separate out computing from plotting. The latter (plotting) can indeed induce a separate set of issues / errors, since it typically requires installing an external library which often dont work on all platforms.

In my case, I failed to instal a plotting library for octave when used within a jupyter notebook or a jupyterhub instance ([e.g. this one](https://github.com/gaelforget/ECCO-Docker)). But I can still run the model even when plotting is not possible -- with the provided modifications to the code.

So in the revised code:

- `SPEAD_1.0/SPEAD_1D.m` is now a function that returns all of the output for plotting later. That is `[dat14,dat15,dat2020a,dat1010,dat1020,dat1022,dat1030,dat2010,dat2020,dat2030,dat70,dat80,dat24]` where each _dat_ is for one plot.
- `SPEAD_1.0/TOOLBOX/MYFUNCTIONS/myheadloadpackages.m` now has an off switch to avoid error when lacking the ability to plot.
- other plotting codes that were inside `SPEAD_1D.m` have now been moved to `SPEAD_1D_plot.m` -- but I did not finish this.
- `SPEAD_1D_save.m` is meant for saving `[dat14,dat15,dat2020a,dat1010,dat1020,dat1022,dat1030,dat2010,dat2020,dat2030,dat70,dat80,dat24]` to files (which would allow for plotting at a later time in a different octave session) -- but not finished either.

Both `SPEAD_1D_plot.m` and `SPEAD_1D_save.m` are work in progress (and I am kind of hoping one of you might finish these off instead of me).

Yet you should right away be able to run the modified `SPEAD_1.0/SPEAD_1D.m` with or without plotting library:

```
addpath(genpath('SPEAD_1.0'))
[dat14,dat15,dat2020,dat1010,dat1020,dat1022,dat1030,dat2010,dat2020,dat2030,dat70,dat80,dat24]=SPEAD_1D();
```

ps. I was talking about this with @serman24 ; am repeating here what I explained in person

